### PR TITLE
Graphics for Discord

### DIFF
--- a/graphics/__init__.py
+++ b/graphics/__init__.py
@@ -1,0 +1,11 @@
+from io import BytesIO
+from discord import File
+
+from .board_svg import create_board
+from .svg_to_png import render_as_png, RendererNotFoundError
+
+
+def render_for_discord(board, filename, rectangle_width, rectangle_height, background):
+    svg = create_board(rectangle_width, rectangle_height, board)
+    png = render_as_png(svg, rectangle_width, rectangle_height, background)
+    return File(BytesIO(png), filename=filename)

--- a/graphics/board_svg.py
+++ b/graphics/board_svg.py
@@ -1,0 +1,156 @@
+from string import ascii_lowercase
+from pathlib import Path
+
+# For traceabilty to the code in `…/boost-app/src/features/play/board.js` in the
+# original PWA, which scales everything to pixels for compatibility with
+# `react-flip-toolkit`, we also do the same here.  The UNSCALED_* constants
+# below are measured in points on the board, whereas the SCALED_* constants are
+# measured in pixels.
+
+UNSCALED_LINE_WIDTH = 1 / 32
+UNSCALED_FONT_HEIGHT = 3 / 8
+UNSCALED_FONT_WIDTH = (2 / 3) * UNSCALED_FONT_HEIGHT
+UNSCALED_DOT_RADIUS = 3 / 32
+UNSCALED_TARGET_RADIUS = 3 / 8
+UNSCALED_TARGET_THICKNESS = 1 / 16
+
+SCALED_BOARD_SHADOW = 5
+SCALED_BOARD_ROUNDING = 8
+
+PIECES_DIRECTORY = (Path(__file__).parent / 'pieces').absolute()
+COLORED_PIECES = {
+    'Pawn',
+    'Knight',
+    'Tower',
+}
+PIECE_FILENAMES = {
+    'Dragon': 'dragon.svg',
+    'Pawn': 'pawn.svg',
+    'Knight': 'knight.svg',
+    'Tower': 'tower.svg',
+}
+
+
+def prettify_file(x):
+    return ascii_lowercase[x]
+
+def prettify_rank(y):
+    return str(y + 1)
+
+def get_image_path(piece):
+    result = PIECES_DIRECTORY
+    if piece.name in COLORED_PIECES:
+        result /= piece.color
+    return result / PIECE_FILENAMES[piece.name]
+
+
+def create_surface(scale, width, height):
+    return f'''
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="{SCALED_BOARD_SHADOW}" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <rect
+    x="{0}"
+    y="{0}"
+    width="{scale * width}"
+    height="{scale * height}"
+    rx="{SCALED_BOARD_ROUNDING}"
+    stroke="none"
+    fill="rgba(127, 199, 127, 1)"
+    filter="url(#shadow)" />
+'''
+
+def create_file(scale, x, length, name):
+    return f'''
+  <line
+    x1="{scale * (x + 0.5)}"
+    y1="{scale * length}"
+    x2="{scale * (x + 0.5)}"
+    y2="{0}"
+    stroke="rgba(0, 0, 0, 1)"
+    stroke-width="{scale * UNSCALED_LINE_WIDTH}" />
+  <text
+    x="{scale * (x + 0.5)}"
+    y="{scale * (length + UNSCALED_FONT_HEIGHT)}"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-family="sans-serif"
+    font-size="{scale * UNSCALED_FONT_HEIGHT}">{name}</text>
+'''
+
+def create_rank(scale, y, max_y, length, name):
+    return f'''
+  <line
+    x1="{0}"
+    y1="{scale * ((max_y - y) + 0.5)}"
+    x2="{scale * length}"
+    y2="{scale * ((max_y - y) + 0.5)}"
+    stroke="rgba(0, 0, 0, 1)"
+    stroke-width="{scale * UNSCALED_LINE_WIDTH}" />
+  <text
+    x="{scale * -UNSCALED_FONT_WIDTH}"
+    y="{scale * ((max_y - y) + 0.5)}"
+    text-anchor="middle"
+    dominant-baseline="middle"
+    font-family="sans-serif"
+    font-size="{scale * UNSCALED_FONT_HEIGHT}">{name}</text>
+'''
+
+def create_dot(scale, x, y, max_y):
+    return f'''
+<circle
+  cx="{scale * (x + 0.5)}"
+  cy="{scale * ((max_y - y) + 0.5)}"
+  r="{scale * UNSCALED_DOT_RADIUS}"
+  stroke="rgba(0, 0, 0, 1)"
+  fill="rgba(0, 0, 0, 1)" />
+'''
+
+def create_board_markings(scale, width, height):
+    results = [create_surface(scale, width, height)]
+    for x in range(width):
+        results.append(create_file(scale, x, height, prettify_file(x)))
+    for y in range(height):
+        results.append(create_rank(scale, y, height - 1, width, prettify_rank(y)))
+    for x in range(width):
+        for y in range(height):
+            results.append(create_dot(scale, x, y, height - 1))
+    return '\n'.join(results)
+
+def create_piece(scale, x, y, max_y, image_path):
+    return f'''
+  <image
+    x="{scale * x}"
+    y="{scale * (max_y - y)}"
+    width="{scale}"
+    height="{scale}"
+    href="{image_path.as_uri()}" />
+'''
+
+def create_pieces(scale, board):
+    max_y = board.height - 1
+    results = []
+    for cell in board.cells:
+        piece = board.get_piece(cell)
+        if piece is not None:
+            results.append(create_piece(
+                scale,
+                cell.col,
+                max_y - cell.row,
+                max_y,
+                get_image_path(piece),
+            ))
+    return '\n'.join(results)
+
+def create_board(rectangle_width, rectangle_height, board):
+    scale = min(rectangle_width / board.width, rectangle_height / board.height)
+    bleed = scale * (2 * UNSCALED_FONT_HEIGHT) / min(board.width, board.height)
+    view_box = f'{-bleed * board.width} {-bleed * board.height} ' + \
+               f'{(scale + 2 * bleed) * board.width} {(scale + 2 * bleed) * board.height}'
+    markings = create_board_markings(scale, board.width, board.height)
+    pieces = create_pieces(scale, board)
+    return f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="{view_box}">{markings}{pieces}</svg>'

--- a/graphics/pieces/black/knight.svg
+++ b/graphics/pieces/black/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 0, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(255, 255, 255, 1)" stroke="rgba(255, 255, 255, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(0, 0, 0, 1)" stroke="rgba(0, 0, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/black/pawn.svg
+++ b/graphics/pieces/black/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 0, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/black/tower.svg
+++ b/graphics/pieces/black/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 0, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(255, 255, 255, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(0, 0, 0, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(0, 0, 0, 1)" d="M 128 128
+			             L 384 384
+			             M 128 384
+			             L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/blue/knight.svg
+++ b/graphics/pieces/blue/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(0, 0, 255, 1)" stroke="rgba(0, 0, 255, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(0, 0, 127, 1)" stroke="rgba(0, 0, 127, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/blue/pawn.svg
+++ b/graphics/pieces/blue/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/blue/tower.svg
+++ b/graphics/pieces/blue/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(0, 0, 255, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(0, 0, 127, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(0, 0, 127, 1)" d="M 128 128
+			               L 384 384
+			               M 128 384
+			               L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/cyan/knight.svg
+++ b/graphics/pieces/cyan/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 127, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(0, 255, 255, 1)" stroke="rgba(0, 255, 255, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(0, 127, 127, 1)" stroke="rgba(0, 127, 127, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/cyan/pawn.svg
+++ b/graphics/pieces/cyan/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 127, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/cyan/tower.svg
+++ b/graphics/pieces/cyan/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 127, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(0, 255, 255, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(0, 127, 127, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(0, 127, 127, 1)" d="M 128 128
+			                 L 384 384
+			                 M 128 384
+			                 L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/dragon.svg
+++ b/graphics/pieces/dragon.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <marker id="arrow" viewBox="-128 0 256 128" refX="0" refY="64"
+          markerUnits="userSpaceOnUse" markerWidth="256" markerHeight="128"
+          orient="auto">
+    <path d="M 0 64
+             C 32 64 0 96 -24 112
+             C 0 112 64 112 90.50966799187808 26.509667991878132
+             z" stroke="rgba(207, 207, 207, 1)" stroke-width="10" stroke-linejoin="round" fill="rgba(207, 207, 207, 1)" />
+  </marker>
+  <circle cx="256" cy="256" r="224" stroke="rgba(127, 127, 127, 1)" stroke-width="12" fill="rgba(127, 127, 127, 1)" filter="url(#shadow)" />
+  <path d="M 384 256
+           L 346.5096679918781 165.4903320081219
+           L 256 128
+           L 165.4903320081219 165.4903320081219
+           L 128 256
+           L 165.4903320081219 346.5096679918781
+           L 256 384
+           L 346.5096679918781 346.5096679918781
+           L 384 256
+           L 346.5096679918781 165.4903320081219"
+        fill="rgba(207, 207, 207, 1)" stroke="none" marker-mid="url(#arrow)" />
+  <circle cx="256" cy="256" r="80"
+          fill="rgba(127, 127, 127, 1)" stroke="rgba(127, 127, 127, 1)" stroke-width="12" />
+  <path d="M 277 96
+           C 235 129 176 192 176 256
+           L 288 184
+           C 264 184 232 184 216 164
+           C 236 132 256 108 308 96
+           C 292 92 284 92 277 96
+           z"
+        fill="rgba(127, 127, 127, 1)" stroke="rgba(127, 127, 127, 1)" stroke-width="12" stroke-linejoin="round" stroke-linecap="round" />
+  <path d="M 280 128
+           C 288 128 296 127 300 126
+           C 302 124 304 122 306 118
+           C 296 118 288 122 280 128
+           z"
+        fill="rgba(127, 127, 127, 1)" stroke="rgba(127, 127, 127, 1)" stroke-width="6" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/green/knight.svg
+++ b/graphics/pieces/green/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 127, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(0, 255, 0, 1)" stroke="rgba(0, 255, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(0, 127, 0, 1)" stroke="rgba(0, 127, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/green/pawn.svg
+++ b/graphics/pieces/green/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 127, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/green/tower.svg
+++ b/graphics/pieces/green/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(0, 127, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(0, 255, 0, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(0, 127, 0, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(0, 127, 0, 1)" d="M 128 128
+			               L 384 384
+			               M 128 384
+			               L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/magenta/knight.svg
+++ b/graphics/pieces/magenta/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(127, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(255, 0, 255, 1)" stroke="rgba(255, 0, 255, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(127, 0, 127, 1)" stroke="rgba(127, 0, 127, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/magenta/pawn.svg
+++ b/graphics/pieces/magenta/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(127, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/magenta/tower.svg
+++ b/graphics/pieces/magenta/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(127, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(255, 0, 255, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(127, 0, 127, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(127, 0, 127, 1)" d="M 128 128
+			                 L 384 384
+			                 M 128 384
+			                 L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/orange/knight.svg
+++ b/graphics/pieces/orange/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(191, 95, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(255, 127, 0, 1)" stroke="rgba(255, 127, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(191, 95, 0, 1)" stroke="rgba(191, 95, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/orange/pawn.svg
+++ b/graphics/pieces/orange/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(191, 95, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/orange/tower.svg
+++ b/graphics/pieces/orange/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(191, 95, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(255, 127, 0, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(191, 95, 0, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(191, 95, 0, 1)" d="M 128 128
+			                L 384 384
+			                M 128 384
+			                L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/pink/knight.svg
+++ b/graphics/pieces/pink/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(255, 127, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(255, 191, 191, 1)" stroke="rgba(255, 191, 191, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(255, 127, 127, 1)" stroke="rgba(255, 127, 127, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/pink/pawn.svg
+++ b/graphics/pieces/pink/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(255, 127, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/pink/tower.svg
+++ b/graphics/pieces/pink/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(255, 127, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(255, 191, 191, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(255, 127, 127, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(255, 127, 127, 1)" d="M 128 128
+			                   L 384 384
+			                   M 128 384
+			                   L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/red/knight.svg
+++ b/graphics/pieces/red/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(127, 0, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(255, 0, 0, 1)" stroke="rgba(255, 0, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(127, 0, 0, 1)" stroke="rgba(127, 0, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/red/pawn.svg
+++ b/graphics/pieces/red/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(127, 0, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/red/tower.svg
+++ b/graphics/pieces/red/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(127, 0, 0, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(255, 0, 0, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(127, 0, 0, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(127, 0, 0, 1)" d="M 128 128
+			               L 384 384
+			               M 128 384
+			               L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/violet/knight.svg
+++ b/graphics/pieces/violet/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(63, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(127, 0, 255, 1)" stroke="rgba(127, 0, 255, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(63, 0, 127, 1)" stroke="rgba(63, 0, 127, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/violet/pawn.svg
+++ b/graphics/pieces/violet/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(63, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/violet/tower.svg
+++ b/graphics/pieces/violet/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(63, 0, 127, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(127, 0, 255, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(63, 0, 127, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(63, 0, 127, 1)" d="M 128 128
+			                L 384 384
+			                M 128 384
+			                L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/white/knight.svg
+++ b/graphics/pieces/white/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(255, 255, 255, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(0, 0, 0, 1)" stroke="rgba(0, 0, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(255, 255, 255, 1)" stroke="rgba(255, 255, 255, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/white/pawn.svg
+++ b/graphics/pieces/white/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(255, 255, 255, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/white/tower.svg
+++ b/graphics/pieces/white/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(255, 255, 255, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(0, 0, 0, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(255, 255, 255, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(255, 255, 255, 1)" d="M 128 128
+			                   L 384 384
+			                   M 128 384
+			                   L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/pieces/yellow/knight.svg
+++ b/graphics/pieces/yellow/knight.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(191, 191, 63, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <path d="M 256 416
+  	   C 316 399 365 304 365 147
+  	   C 331 177 274 126 256 96
+  	   C 238 126 181 177 147 147
+  	   C 147 304 196 399 256 416
+  	   z" fill="rgba(255, 255, 0, 1)" stroke="rgba(255, 255, 0, 1)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M 256 352
+  	   C 292 342 321 285 321 191
+  	   C 301 209 267 178 256 160
+  	   C 245 178 211 209 191 191
+  	   C 191 285 220 342 256 352
+  	   z" fill="rgba(191, 191, 63, 1)" stroke="rgba(191, 191, 63, 1)" stroke-width="12" stroke-linejoin="round" />
+</svg>

--- a/graphics/pieces/yellow/pawn.svg
+++ b/graphics/pieces/yellow/pawn.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(191, 191, 63, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+</svg>

--- a/graphics/pieces/yellow/tower.svg
+++ b/graphics/pieces/yellow/tower.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <filter id="shadow">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="16" />
+    <feMerge>
+      <feMergeNode />
+      <feMergeNode in="SourceGraphic" />
+    </feMerge>
+  </filter>
+  <circle fill="rgba(191, 191, 63, 1)" cx="256" cy="256" r="224" filter="url(#shadow)" />
+  <circle fill="rgba(255, 255, 0, 1)" cx="256" cy="256" r="180" />
+  <circle fill="rgba(191, 191, 63, 1)" cx="256" cy="256" r="140" />
+  <path stroke="rgba(191, 191, 63, 1)" d="M 128 128
+			                  L 384 384
+			                  M 128 384
+			                  L 384 128" stroke-width="20" />
+</svg>

--- a/graphics/svg_to_png.py
+++ b/graphics/svg_to_png.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python3
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from subprocess import run, CalledProcessError
+
+
+RENDERER_CANDIDATES = (
+    'chromium',
+    'chrome',
+)
+
+
+class RendererNotFoundError(OSError):
+    pass
+
+
+def render_as_png(svg, width, height, background='ffffffff'):
+    with NamedTemporaryFile('w', suffix='.svg', dir=Path(), delete=False) as svg_file:
+        svg_file.write(svg)
+    with NamedTemporaryFile('w', suffix='.png', dir=Path(), delete=False) as png_file:
+        pass
+    try:
+        for renderer in RENDERER_CANDIDATES:
+            try:
+                run([
+                    renderer,
+                    '--incognito',
+                    '--headless',
+                    '--hide-scrollbars',
+                    f'--window-size={width},{height}',
+                    f'--default-background-color={background}',
+                    f'--screenshot={png_file.name}',
+                    svg_file.name,
+                ], check=True)
+            except (FileNotFoundError, CalledProcessError):
+                pass
+            else:
+                with open(png_file.name, 'rb') as file:
+                    return file.read()
+        raise RendererNotFoundError(
+            'Unable to find Chromium-based browser in PATH with which to render an SVG.',
+        )
+    finally:
+        Path(svg_file.name).unlink()
+        Path(png_file.name).unlink()


### PR DESCRIPTION
I had some time snowed in this morning, so I added support for rendering the board as an image and posting that to Discord.  With this PR, the bot will look for Chromium or Chrome in its `PATH`, and, if one of those browsers is available, use it as a library to render a board SVG as a PNG that can be posted to Discord.  If neither browser can be found, it falls back to text-based messages.  (If performance is important, it probably makes more sense to render PNGs directly, since invoking a browser isn't the fastest operation.  On the other hand, rendering via SVG makes it a lot easier to tweak the graphics, which I thought might be better given the "new piece types" section of the to-do list.)

I didn't quite know the best place to put this code, but I tentatively threw it in a `graphics` folder.  The main rendering code is in `…/graphics/board_svg.py` and is written to be as traceable as possible to `…/boost-app/src/features/play/board.js` from the original PWA.  `…/graphics/svg_to_png.py` contains the code for talking to Chromium/Chrome, which is necessary because Discord unfortunately doesn't display attached SVGs, only GIFs and PNGs.

I tried to minimize changes to the existing code as much as possible, but there's probably some code simplification possible depending on what you want to do with the design.  For example, `…/graphics/board_svg.py` contains its own methods, `prettify_file` and `prettify_rank` for naming files and ranks since I didn't have direct access to those behaviors without refactoring code like the `format_cell` method in the `Board` class.  Similarly, in `create_pieces` in `…/graphics/board_svg.py`, I thought I could use the `Board` class's `pieces` property, but it turns out that's actually an accessor for piece counts, not the pieces themselves, so I used the `cells` property and the `get_piece` method instead.  A (generator function?) accessor for a board's pieces might be nicer though.

This change does provoke some Pylint warnings under the default Pylint configuration, but they seem innocuous:
*   I did not include docstrings since the other code was not docstringed.
*   Pylint is unhappy to have variables for x and y coordinates named `x` and `y`.
